### PR TITLE
Add dark mode support

### DIFF
--- a/app/components/EnvironmentSelector.tsx
+++ b/app/components/EnvironmentSelector.tsx
@@ -32,19 +32,19 @@ export default function EnvironmentSelector() {
         onClick={() => setIsOpen(!isOpen)}
         className={`flex items-center space-x-1 text-sm px-3 py-1 rounded border transition-colors duration-300 ${
           isChanging 
-            ? 'bg-blue-100 text-blue-700 border-blue-300' 
-            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200'
+            ? 'bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900 dark:text-blue-300 dark:border-blue-700' 
+            : 'bg-gray-100 text-gray-700 border-gray-300 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700 dark:hover:bg-gray-700'
         }`}
       >
         <span>{currentEnv.name}</span>
-        <span className="text-xs text-gray-500">({currentEnv.region})</span>
+        <span className="text-xs text-gray-500 dark:text-gray-400">({currentEnv.region})</span>
         <span className="ml-1">{isOpen ? '▲' : '▼'}</span>
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-1 bg-white border border-gray-300 rounded shadow-lg z-10 w-64">
-          <div className="p-2 border-b border-gray-200 bg-gray-50">
-            <h3 className="text-xs font-semibold text-gray-700">Select Environment</h3>
+        <div className="absolute right-0 mt-1 bg-white dark:bg-dark-card border border-gray-300 dark:border-dark-border rounded shadow-lg z-10 w-64">
+          <div className="p-2 border-b border-gray-200 dark:border-dark-border bg-gray-50 dark:bg-gray-800">
+            <h3 className="text-xs font-semibold text-gray-700 dark:text-gray-300">Select Environment</h3>
           </div>
           <div className="p-2">
             {environments.map(env => (
@@ -58,8 +58,8 @@ export default function EnvironmentSelector() {
                   className="mr-2"
                 />
                 <label htmlFor={`env-${env.id}`} className="flex flex-col cursor-pointer">
-                  <span className="text-sm">{env.name}</span>
-                  <span className="text-xs text-gray-500">{env.region}</span>
+                  <span className="text-sm dark:text-gray-200">{env.name}</span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">{env.region}</span>
                 </label>
               </div>
             ))}

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useTheme } from '../context/ThemeContext';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+      title={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      {theme === 'light' ? (
+        // Moon icon for dark mode
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-700" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+        </svg>
+      ) : (
+        // Sun icon for light mode
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-yellow-300" viewBox="0 0 20 20" fill="currentColor">
+          <path fillRule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clipRule="evenodd" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  // Initialize theme from localStorage if available, otherwise use system preference
+  const [theme, setTheme] = useState<Theme>('light');
+  
+  useEffect(() => {
+    // On mount, read the theme from localStorage or use system preference
+    const storedTheme = localStorage.getItem('theme') as Theme | null;
+    
+    if (storedTheme) {
+      setTheme(storedTheme);
+    } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+  
+  useEffect(() => {
+    // Apply theme to document when theme changes
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    
+    // Store theme preference in localStorage
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+  
+  const toggleTheme = () => {
+    setTheme(prevTheme => prevTheme === 'light' ? 'dark' : 'light');
+  };
+  
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import type { ReactNode } from 'react';
 import Icon from './components/Icon';
 import EnvironmentSelector from './components/EnvironmentSelector';
 import { EnvironmentProvider } from './context/EnvironmentContext';
+import { ThemeProvider } from './context/ThemeContext';
+import ThemeToggle from './components/ThemeToggle';
 
 export const metadata = {
   title: 'AWS TGSAIOps Dashboard',
@@ -12,9 +14,10 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
-      <body className="flex min-h-screen font-sans text-sm">
+    <html lang="en" className="light">
+      <body className="flex min-h-screen font-sans text-sm dark:bg-dark-bg dark:text-dark-text">
         <EnvironmentProvider>
+          <ThemeProvider>
         {/* Sidebar */}
         <aside className="w-64 bg-gray-900 text-gray-300 flex flex-col">
           <div className="p-4 border-b border-gray-700">
@@ -69,20 +72,22 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         {/* Main Content Area */}
         <div className="flex-1 flex flex-col">
           {/* Header */}
-          <header className="bg-white border-b border-gray-300 p-3 flex justify-between items-center shadow-sm">
+          <header className="bg-white dark:bg-dark-card border-b border-gray-300 dark:border-dark-border p-3 flex justify-between items-center shadow-sm">
             <div className="flex items-center">
               {/* Placeholder for Search */}
-              <input type="text" placeholder="Search..." className="border border-gray-300 rounded px-3 py-1 text-sm mr-4" />
+              <input type="text" placeholder="Search..." className="border border-gray-300 dark:border-dark-border dark:bg-dark-card dark:text-dark-text rounded px-3 py-1 text-sm mr-4" />
             </div>
             <div className="flex items-center space-x-4">
               <EnvironmentSelector />
+              <ThemeToggle />
               {/* Placeholder for User Menu */}
-              <button className="text-sm text-gray-700">admin@example.com ▼</button>
+              <button className="text-sm text-gray-700 dark:text-dark-text">admin@example.com ▼</button>
             </div>
           </header>
           {/* Page Content */}
-          <main className="flex-1 p-6 bg-gray-100 overflow-y-auto">{children}</main>
+          <main className="flex-1 p-6 bg-gray-100 dark:bg-dark-bg overflow-y-auto">{children}</main>
         </div>
+          </ThemeProvider>
         </EnvironmentProvider>
       </body>
     </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,23 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  darkMode: 'class', // Enable class-based dark mode
+  theme: {
+    extend: {
+      colors: {
+        // Define custom colors for dark mode if needed
+        dark: {
+          bg: '#121212',
+          card: '#1e1e1e',
+          border: '#2e2e2e',
+          text: '#e0e0e0',
+          muted: '#a0a0a0',
+        },
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
This PR adds dark mode support to the AWS AIOps Dashboard. 

## Features
- Added ThemeContext to manage theme state
- Created ThemeToggle component for switching between light and dark modes
- Configured Tailwind CSS with dark mode support
- Updated layout and components with dark mode classes

## Implementation Details
- Uses class-based dark mode strategy
- Persists user preference in localStorage
- Respects system preference on first visit
- Maintains consistent styling across light and dark themes